### PR TITLE
Remove duplicated slash in the url

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/Dashboard/Applications/Moodle.php
+++ b/root/usr/share/nethesis/NethServer/Module/Dashboard/Applications/Moodle.php
@@ -35,20 +35,19 @@ class Moodle extends \Nethgui\Module\AbstractModule implements \NethServer\Modul
 
     public function getInfo()
     {
-
-        // Set host value based on database configuraiton
+        // Set host value based on database configuration
         if ($this->getPlatform()->getDatabase('configuration')->getProp('moodle','host') != "") {
             $host = $this->getPlatform()->getDatabase('configuration')->getProp('moodle','host');
         } else {
             $host = explode(':', $_SERVER['HTTP_HOST']);
-            $host = $host[0] . '/';
+            $host = $host[0];
         }
 
-
-        // Set path value based on database configuraiton
+        // Set path value based on database configuration
         $path = $this->getPlatform()->getDatabase('configuration')->getProp('moodle','path');
         $apacheConf = $this->getPlatform()->getDatabase('configuration')->getProp('moodle','apacheConf'); 
-        // Set url value based on path
+
+        // Set url value based on apache configuration
         if ( $apacheConf == "virtualhost" )
             $url = "https://" . $host;
         else

--- a/root/usr/share/nethesis/NethServer/Module/Dashboard/Applications/Moodle.php
+++ b/root/usr/share/nethesis/NethServer/Module/Dashboard/Applications/Moodle.php
@@ -45,6 +45,8 @@ class Moodle extends \Nethgui\Module\AbstractModule implements \NethServer\Modul
 
         // Set path value based on database configuration
         $path = $this->getPlatform()->getDatabase('configuration')->getProp('moodle','path');
+
+        // Set apache configuration value based on database configuration
         $apacheConf = $this->getPlatform()->getDatabase('configuration')->getProp('moodle','apacheConf'); 
 
         // Set url value based on apache configuration


### PR DESCRIPTION
- Previously, the url ended with a duplicated slash between host and
  the path values (e.g., 'https://host//path'). This update changes
  Moodle.php to make the url use a single slash between host and path
  (e.g., 'https://host/path'). When the virtualhost configuration is
  used, no trailing slash is used after host (e.g., 'https://host').